### PR TITLE
[vibrator] capture duration by value

### DIFF
--- a/src/vibrator.cpp
+++ b/src/vibrator.cpp
@@ -86,7 +86,7 @@ void Vibrator::vibrate(int durationMs)
 
 void Vibrator::rumble(int durationMs, int repeat)
 {
-    m_repeatThread = std::make_shared<RepeatThread>([&](){
+    m_repeatThread = std::make_shared<RepeatThread>([=](){
         vibrate(durationMs);
     }, durationMs*2, repeat);
 }


### PR DESCRIPTION
`durationMs` argument can't possibly outlive the RepeatThread. Capture
it by value using `=`.