### PR TITLE
Fix HFD daemon for FP2

### DIFF
--- a/src/leds-hybris.cpp
+++ b/src/leds-hybris.cpp
@@ -35,10 +35,6 @@ bool LedsHybris::usable() {
 }
 
 LedsHybris::LedsHybris() : Leds() {
-     if (m_lightDevice) {
-        return;
-    }
-
     int err;
     hw_module_t* module;
 


### PR DESCRIPTION
FP2 lacks timer triggers on its LEDs, choking code which set a trigger for them. I implemented a way to detect if a device lacks timer triggers, and make it failback to hybris backend.

Also, fix hybris backend by stop checking the variable in the constructor. That variable isn't initialized. Checking for it in the constructor creates false-positive which will leave the variable not initialized and crash the daemon later.