### PR TITLE
Fix for E4.5: prioritise Hybris LED backend

### DIFF
--- a/data/hfd-service.conf
+++ b/data/hfd-service.conf
@@ -3,4 +3,15 @@ description "hfd service for feedback support"
 start on started dbus
 stop on stopped dbus
 
+pre-start script
+    # If we're running on Android-based device, we want to wait until the
+    # Android container is up.
+    if [ -e /system/build.prop ]; then
+        while ! initctl status lxc-android-config| \
+                grep -q ' start/running,'; do
+            sleep 0.1
+        done
+    fi
+end script
+
 exec hfd-service

--- a/src/leds.cpp
+++ b/src/leds.cpp
@@ -38,13 +38,13 @@ protected:
 
 std::shared_ptr<Leds> Leds::create()
 {
-    if (LedsSysfs::usable()) {
-        std::cout << "Using sysfs leds" << std::endl;
-        return std::make_shared<LedsSysfs>();
-    }
-    else if (LedsHybris::usable()) {
+    if (LedsHybris::usable()) {
         std::cout << "Using hybris leds" << std::endl;
         return std::make_shared<LedsHybris>();
+    }
+    else if (LedsSysfs::usable()) {
+        std::cout << "Using sysfs leds" << std::endl;
+        return std::make_shared<LedsSysfs>();
     }
 
     std::cout << "Using dummy leds" << std::endl;


### PR DESCRIPTION
Some device, such as bq E4.5, have broken sysfs led nodes which cannot
blink properly in synchronization. In this case, the Android light HAL
is required. So, on Android devices, prefer hybris backend which will
always handle any device specific quirks via HALs.

In case you're wondering what happens on E4.5, its light HAL uses custom
IOCTLs to a custom device node (/dev/rgb_blink). Why would you provide
the sysfs nodes with timer trigger then?

Just in case, I also make the unit waits for Android container so that libhybris
can find the correct linker.