### PR TITLE
Make libhybris optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,22 @@ include(FindPkgConfig)
 include(GNUInstallDirs)
 
 pkg_check_modules(UDEV REQUIRED libudev)
-pkg_check_modules(ANDROID_HEADERS REQUIRED android-headers)
-pkg_check_modules(ANDROID_HARDWARE REQUIRED libhardware)
+
+option(ENABLE_LIBHYBRIS "Enable libhybris support" ON)
+
+if (ENABLE_LIBHYBRIS)
+  pkg_check_modules(ANDROID_HEADERS android-headers)
+  pkg_check_modules(ANDROID_HARDWARE libhardware)
+  if(ANDROID_HEADERS_FOUND AND ANDROID_HARDWARE_FOUND)
+    message(STATUS "Bulding with libhybris support")
+    set(HAVE_LIBHYBRIS true)
+  else()
+    message(WARNING "Bulding without libhybris support, missing required dependencies!")
+  endif()
+else()
+  message(STATUS "Bulding without libhybris support")
+endif()
+
 find_package(Qt5Core REQUIRED)
 find_package(Qt5DBus REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,24 +1,35 @@
 add_subdirectory(udev)
 
-include_directories(
-    ${ANDROID_HEADERS_INCLUDE_DIRS}
-)
+if (HAVE_LIBHYBRIS)
+    include_directories(
+        ${ANDROID_HEADERS_INCLUDE_DIRS}
+    )
 
+    set(LIBHYBRIS_SRC
+        leds-hybris.cpp
+    )
 
+    set(LIBHYBRIS_LIBRARIES
+        ${ANDROID_HARDWARE_LIBRARIES}
+    )
+
+    add_definitions(-DHAVE_LIBHYBRIS)
+endif()
 
 add_library(hfd-core STATIC
     leds.cpp
     leds-sysfs.cpp
-    leds-hybris.cpp
 
     vibrator.cpp
     vibrator-sysfs.cpp
     vibrator-legacy.cpp
+
+    ${LIBHYBRIS_SRC}
 )
 
 target_link_libraries(hfd-core
     udev-cpp
-    ${ANDROID_HARDWARE_LIBRARIES}
+    ${LIBHYBRIS_LIBRARIES}
 )
 
 set(SERVICE_SRC
@@ -29,8 +40,6 @@ set(SERVICE_SRC
 qt5_add_dbus_adaptor(SERVICE_SRC
     ${CMAKE_SOURCE_DIR}/data/com.lomiri.hfd.xml ${CMAKE_CURRENT_SOURCE_DIR}/dbusAdaptor.h DbusAdaptor
 )
-
-message("ff ${SERVICE_SRC}")
 
 add_executable(hfd-service
     ${SERVICE_SRC} 

--- a/src/leds.cpp
+++ b/src/leds.cpp
@@ -18,7 +18,10 @@
 
 #include "leds.h"
 #include "leds-sysfs.h"
+
+#ifdef HAVE_LIBHYBRIS
 #include "leds-hybris.h"
+#endif
 
 #include <iostream>
 
@@ -38,11 +41,14 @@ protected:
 
 std::shared_ptr<Leds> Leds::create()
 {
+#ifdef HAVE_LIBHYBRIS
     if (LedsHybris::usable()) {
         std::cout << "Using hybris leds" << std::endl;
         return std::make_shared<LedsHybris>();
     }
-    else if (LedsSysfs::usable()) {
+    else
+#endif
+    if (LedsSysfs::usable()) {
         std::cout << "Using sysfs leds" << std::endl;
         return std::make_shared<LedsSysfs>();
     }
@@ -55,11 +61,14 @@ std::shared_ptr<Leds> Leds::create(std::string type)
 {
     if (type == "sysfs") {
         std::cout << "Using sysfs leds" << std::endl;
-        return std::make_shared<LedsSysfs>();    
-    } else if (type == "hybris") {
+        return std::make_shared<LedsSysfs>();
+    }
+#ifdef HAVE_LIBHYBRIS
+    else if (type == "hybris") {
         std::cout << "Using hybris leds" << std::endl;
         return std::make_shared<LedsHybris>();
     }
+#endif
 
     std::cout << "Using dummy leds" << std::endl;
     return std::make_shared<LedsDummy>();


### PR DESCRIPTION
This makes libhybris optional as it wont be needed for some of our
downstream users.