### PR TITLE
vibrator-sysfs: Don't crash when failing to add transient trigger

### DIFF
--- a/src/udev/udevDevice.cpp
+++ b/src/udev/udevDevice.cpp
@@ -138,7 +138,7 @@ namespace Udev
 	}
 
 	void UdevDevice::set_sysattr(const std::string named, const std::string value) const
-{
+	{
 		int ret = udev_device_set_sysattr_value(handle, named.c_str(), (char*)value.c_str());
 		if (ret < 0)
 		{

--- a/src/vibrator-sysfs.cpp
+++ b/src/vibrator-sysfs.cpp
@@ -34,7 +34,12 @@ VibratorSysfs::VibratorSysfs(): Vibrator() {
 
     m_device = udev.device_from_syspath("/sys/class/leds/vibrator");
 
-    m_device.set_sysattr("trigger", "transient");
+    try {
+        m_device.set_sysattr("trigger", "transient");
+    } catch (const std::runtime_error& e) {
+        (void)e;
+        std::cerr << "Failed to add transient trigger, usually non-fatal" << std::endl;
+    }
 
     // Make sure we are off on init
     configure(State::Off, 0);

--- a/src/vibrator-sysfs.h
+++ b/src/vibrator-sysfs.h
@@ -34,5 +34,6 @@ protected:
     
 private:
     Udev::UdevDevice m_device;
+    static bool supportTransient();
 };
 }


### PR DESCRIPTION
Trying to add triggers to the vibrator fails on the OnePlus 6, but this isn't fatal. Catch and print the error but keep running as the device might just work anyway.