### PR TITLE
upstart: Speed up waiting for lxc-android-config to be up

### DIFF
--- a/data/hfd-service.conf
+++ b/data/hfd-service.conf
@@ -8,7 +8,7 @@ pre-start script
     # Android container is up.
     if [ -e /system/build.prop ]; then
         while ! initctl status lxc-android-config| \
-                grep -q ' start/running,'; do
+                grep -q ' start/running,\| start/post-start,'; do
             sleep 0.1
         done
     fi


### PR DESCRIPTION
Reduce the time to wait for the LXC container to be up, the GUI
is mostly already up when the container is in 'post-start' state.

This fixes vibration to be available on time on the Pixel 3a.