### PR TITLE
Fix spelling mistakes when DBus connection fails

### DIFF
--- a/src/service.cpp
+++ b/src/service.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
     connection.registerService("com.lomiri.hfd");
 
     if (connection.lastError().isValid()) {
-        std::cout << "Ist not connedted to dbus!!!!" << std::endl;
+        std::cout << "Not connected to DBus!!!" << std::endl;
         qWarning() << connection.lastError();
         return 1;
     }


### PR DESCRIPTION
Also, shouldn't this print to stderr instead?